### PR TITLE
changes documize download url (newer version and plus version)

### DIFF
--- a/data/documize/Dockerfile
+++ b/data/documize/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine as build
 
-ENV DOCUMIZEVERSION=v5.2.1
+ENV DOCUMIZEVERSION=v5.4.1
 
 RUN apk update \
     && apk add curl \
-    && curl -L https://github.com/documize/community/releases/download/${DOCUMIZEVERSION}/documize-community-linux-amd64 --output /usr/local/bin/documize \
+    && curl -L https://community-downloads.s3.us-east-2.amazonaws.com/documize-community-plus-linux-amd64 --output /usr/local/bin/documize \
     && chmod +x /usr/local/bin/documize
 
 FROM gcr.io/distroless/static AS final


### PR DESCRIPTION
takes the download url from their website not from github repo because website download provides the plus version.